### PR TITLE
Fix giveaway code so it rejects bids of size 0 and 32768

### DIFF
--- a/charbot/giveaway.py
+++ b/charbot/giveaway.py
@@ -431,7 +431,7 @@ class BidModal(ui.Modal, title="Bid"):
                 translator.format_value("giveaway-bid-invalid-bid."), ephemeral=True
             )
             return self.stop()
-        if 0 > bid_int < 32768:
+        if 0 >= bid_int <= 32768:
             await interaction.response.send_message(
                 translator.format_value("giveaway-bid-invalid-bid."), ephemeral=True
             )

--- a/i18n/en-US/giveaway.ftl
+++ b/i18n/en-US/giveaway.ftl
@@ -9,4 +9,4 @@ giveaway-alerts-disable = You will no longer receive giveaway alerts.
 giveaway-bid-success = You have bid {$bid} more entries, for a total of {$new_bid} entries, giving you a {NUMBER($chance, style: "percent", maximumFractionDigits: 2, minimumFractionDigits: 2)} chance of winning! You now have {$points} reputation left, and you have won {$wins}/3 giveaways you can this month!
 giveaway-bid-not-enough-rep = You do not have enough reputation to bid {$bid} entries, you need {$points} more.
 giveaway-bid-no-rep = You either have never gained reputation or have 0.
-giveaway-bid-invalid-bid = Please enter a valid integer between 0 and 32768.
+giveaway-bid-invalid-bid = Please enter a valid integer above 0 and less than 32768.


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked 
-->
## Checklist
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md).
- [x] The changes are for an issue, or have been discussed with Bluesy.
- [x] I have checked the code for syntax errors or non conforming style and fixed them to the best of my abilitty.


<!-- 
Write down the changes this PR introduces. 
If there are breaking changes list them separately.
-->
## Changelog
- Rejects Bids of 0 and 32768
- Updates transalation source string for `giveaway-invalid-bid` key

### Breaking Changes


<!-- 
A brief description of what this PR is about if the title is not sufficient
-->
## Description


<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: SENTRY-CHARBOT-30
