### PR TITLE
Typing: Remove custom `discord.Interaction` generics for lib builtin

### DIFF
--- a/charbot/__init__.py
+++ b/charbot/__init__.py
@@ -9,9 +9,7 @@ import pathlib as _pathlib
 import sys as _sys
 from importlib import metadata as _metadata
 from pkgutil import iter_modules
-from typing import Any, Generic, TypeVar
-
-import discord
+from typing import Any
 
 from charbot_rust import translate, __version__ as rust_version
 
@@ -31,16 +29,11 @@ __all__ = (
     "CBot",
     "Tree",
     "Config",
-    "Interaction",
-    "GuildInteraction",
-    "ComponentInteraction",
-    "GuildComponentInteraction",
     "translate",
 )
 __blacklist__ = [f"{__package__}.{item}" for item in ("__main__", "bot", "card", "errors", "types", "translator")]
 
 EXTENSIONS = [module.name for module in iter_modules(__path__, f"{__package__}.") if module.name not in __blacklist__]
-T = TypeVar("T", bound="CBot")
 
 
 class _Config:
@@ -110,28 +103,6 @@ class _Config:
             raise
         finally:
             self.logger.info("Got key %s from config file.", ":".join(args))
-
-
-class Interaction(discord.Interaction, Generic[T]):  # skipcq: PY-D0002
-    client: T
-
-
-class GuildInteraction(Interaction[T]):  # skipcq: PY-D0002
-    client: T
-    guild: discord.Guild
-    user: discord.Member
-
-
-class ComponentInteraction(Interaction[T]):  # skipcq: PY-D0002
-    client: T
-    message: discord.Message
-
-
-class GuildComponentInteraction(Interaction[T]):  # skipcq: PY-D0002
-    client: T
-    guild: discord.Guild
-    message: discord.Message
-    user: discord.Member
 
 
 Config = _Config()

--- a/charbot/admin.py
+++ b/charbot/admin.py
@@ -152,9 +152,7 @@ class Admin(commands.Cog):
                 ret += 1
         await ctx.reply(f"{ret}/{len(members)} members were added to XCOM and recruited.")
 
-    @app_commands.command(
-        name="confirm", description="[Charlie only] confirm a winner"
-    )  # pyright: ignore[reportGeneralTypeIssues]
+    @app_commands.command(name="confirm", description="[Charlie only] confirm a winner")
     @app_commands.guild_only()
     @app_commands.default_permissions(administrator=True)
     @app_commands.checks.cooldown(1, 3600, key=lambda i: i.namespace.member)
@@ -165,7 +163,7 @@ class Admin(commands.Cog):
         ----------
         interaction: charbot.Interaction[CBot]
             The interaction of the command invocation. At runtime, this is a discord.Interaction object, buy for
-             typechecking, it's a charbot.Interaction object to help infer the properties of the object.
+            typechecking, it's a charbot.Interaction object to help infer the properties of the object.
         member : discord.Member
             The user to confirm as a winner.
         """

--- a/charbot/admin.py
+++ b/charbot/admin.py
@@ -7,10 +7,10 @@ from time import perf_counter
 from typing import cast, Final
 
 import discord
-from discord import Color, app_commands, PermissionOverwrite, Permissions
+from discord import Color, Interaction, app_commands, PermissionOverwrite, Permissions
 from discord.ext import commands
 
-from . import CBot, GuildInteraction
+from . import CBot
 
 
 class Admin(commands.Cog):
@@ -158,14 +158,14 @@ class Admin(commands.Cog):
     @app_commands.guild_only()
     @app_commands.default_permissions(administrator=True)
     @app_commands.checks.cooldown(1, 3600, key=lambda i: i.namespace.member)
-    async def confirm(self, interaction: GuildInteraction[CBot], member: discord.Member) -> None:
+    async def confirm(self, interaction: Interaction[CBot], member: discord.Member) -> None:
         """Confirm a winner.
 
         Parameters
         ----------
-        interaction: charbot.GuildInteraction[CBot]
+        interaction: charbot.Interaction[CBot]
             The interaction of the command invocation. At runtime, this is a discord.Interaction object, buy for
-             typechecking, it's a charbot.GuildInteraction object to help infer the properties of the object.
+             typechecking, it's a charbot.Interaction object to help infer the properties of the object.
         member : discord.Member
             The user to confirm as a winner.
         """

--- a/charbot/betas/cog.py
+++ b/charbot/betas/cog.py
@@ -69,7 +69,7 @@ class Betas(commands.Cog):
                     )
                     # await conn.execute("UPDATE users SET points = points - 50 WHERE id = $1", member.id)
 
-    @banner.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @banner.command()
     @app_commands.checks.cooldown(2, 60 * 60 * 24 * 7 * 4, key=lambda i: i.user.id)  # pragma: no branch
     async def request(
         self,
@@ -150,7 +150,7 @@ class Betas(commands.Cog):
             )
             await interaction.followup.send(f"You now have {remaining} rep remaining.\nYou have requested a banner!")
 
-    @banner.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @banner.command()
     async def status(self, interaction: Interaction[CBot]) -> None:
         """Check the status of your banner request.
 

--- a/charbot/betas/cog.py
+++ b/charbot/betas/cog.py
@@ -15,13 +15,13 @@ from typing import Final, cast
 import asyncpg
 import discord
 from PIL import Image
-from discord import app_commands, utils
+from discord import Interaction, app_commands, utils
 from discord.ext import commands
 
 from . import ColorOpts, views
 from .banner import generate_banner
 from ._types import BannerStatus, BannerStatusPoints
-from .. import GuildInteraction as Interaction, CBot
+from .. import CBot
 
 
 BASE_PATH: Final[Path] = Path(__file__).parent / "user_assets"
@@ -171,7 +171,7 @@ class Betas(commands.Cog):
         if banner_rec["approved"] is False:
             await interaction.followup.send("Your banner_rec is still pending approval!")
             return
-        banner_bytes = await generate_banner(banner_rec, interaction.user)
+        banner_bytes = await generate_banner(banner_rec, cast(discord.Member, interaction.user))
         banner_file = discord.File(banner_bytes, filename="banner.png")
         await interaction.followup.send(
             f"Your banner has been approved and is as follows! Cooldown until: "

--- a/charbot/betas/views/banner.py
+++ b/charbot/betas/views/banner.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: MIT
 """Banner approval flow."""
 import discord
-from discord import ui
+from discord import Interaction, ui
 
 from .._types import BannerStatus
-from ... import GuildComponentInteraction as Interaction, CBot
+from ... import CBot
 
 
 class ApprovalView(ui.View):

--- a/charbot/betas/views/banner.py
+++ b/charbot/betas/views/banner.py
@@ -31,7 +31,7 @@ class ApprovalView(ui.View):
         """Check if the interaction is valid."""
         return interaction.user.id == self.mod
 
-    @ui.button(label="Approve", style=discord.ButtonStyle.green)  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Approve", style=discord.ButtonStyle.green)
     async def approve(self, interaction: Interaction[CBot], _: ui.Button):
         """Approve the banner."""
         await interaction.response.defer(ephemeral=True)
@@ -41,7 +41,7 @@ class ApprovalView(ui.View):
         await interaction.edit_original_response(content="Banner approved.", attachments=[], view=None)
         self.stop()
 
-    @ui.button(label="Deny", style=discord.ButtonStyle.red)  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Deny", style=discord.ButtonStyle.red)
     async def deny(self, interaction: Interaction[CBot], _: ui.Button):
         """Deny the banner."""
         await interaction.response.defer(ephemeral=True)
@@ -49,7 +49,7 @@ class ApprovalView(ui.View):
         await interaction.edit_original_response(content="Banner denied.", attachments=[], view=None)
         self.stop()
 
-    @ui.button(label="Cancel", style=discord.ButtonStyle.blurple)  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Cancel", style=discord.ButtonStyle.blurple)
     async def cancel(self, interaction: Interaction[CBot], _: ui.Button):
         """Cancel the banner."""
         await interaction.response.defer(ephemeral=True)

--- a/charbot/bot.py
+++ b/charbot/bot.py
@@ -437,7 +437,7 @@ class Tree(app_commands.CommandTree[CBot]):
         self.logger = logging.getLogger("charbot.tree")
 
     async def on_error(
-        self, interaction: discord.Interaction, error: app_commands.AppCommandError
+        self, interaction: discord.Interaction[CBot], error: app_commands.AppCommandError
     ) -> None:  # pragma: no cover
         """Event triggered when an error is raised while invoking a command.
 

--- a/charbot/giveaway/modal.py
+++ b/charbot/giveaway/modal.py
@@ -7,14 +7,13 @@
 from __future__ import annotations
 
 import discord
-from discord import ui
+from discord import Interaction, ui
 from typing import TYPE_CHECKING, cast
 
 import charbot_rust
 
 if TYPE_CHECKING:  # pragma: no cover
     from . import GiveawayView, CBot
-    from .. import GuildComponentInteraction as Interaction
 
 
 def rectify_bid(bid_int: int, current_bid: int | None, points: int) -> int:
@@ -73,7 +72,7 @@ class BidModal(ui.Modal, title="Bid"):
         required=True,
     )
 
-    async def on_submit(self, interaction: "Interaction[CBot]") -> None:
+    async def on_submit(self, interaction: Interaction["CBot"]) -> None:
         """Call when a bid modal is submitted.
 
         Parameters
@@ -179,7 +178,7 @@ class BidModal(ui.Modal, title="Bid"):
             return False
         return True
 
-    async def invalid_bid(self, interaction):
+    async def invalid_bid(self, interaction: Interaction["CBot"]):
         """Call when a bid is invalid."""
         await interaction.response.send_message(
             charbot_rust.translate(interaction.locale.value, "giveaway-bid-invalid-bid", {}), ephemeral=True

--- a/charbot/giveaway/view.py
+++ b/charbot/giveaway/view.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import asyncpg
 import discord
-from discord import ui
+from discord import Interaction, ui
 from discord.utils import MISSING, utcnow
 
 import charbot_rust
@@ -21,10 +21,10 @@ from . import BidModal
 from .. import errors
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .. import CBot, GuildComponentInteraction as Interaction
+    from .. import CBot
 
 
-async def hit_max_wins(interaction):
+async def hit_max_wins(interaction: Interaction["CBot"]):
     """Standard response for when a user has hit max wins for a month."""
     try:
         await interaction.response.send_message(
@@ -119,7 +119,7 @@ class GiveawayView(ui.View):
             raise KeyError("Invalid giveaway embed.") from e
         return view
 
-    async def interaction_check(self, interaction: "Interaction[CBot]") -> bool:  # pragma: no cover
+    async def interaction_check(self, interaction: Interaction["CBot"]) -> bool:  # pragma: no cover
         """Check if the interaction is valid.
         Parameters
         ----------
@@ -139,7 +139,7 @@ class GiveawayView(ui.View):
         return True
 
     async def on_error(
-        self, interaction: "Interaction[CBot]", error: Exception, item: ui.Item[Any]
+        self, interaction: Interaction["CBot"], error: Exception, item: ui.Item[Any]
     ) -> None:  # pragma: no cover
         """Error handler.
         Parameters
@@ -303,7 +303,7 @@ class GiveawayView(ui.View):
 
     # noinspection PyUnusedLocal
     @ui.button(label="Bid", style=discord.ButtonStyle.green)  # pyright: ignore[reportGeneralTypeIssues]
-    async def bid(self, interaction: "Interaction[CBot]", button: ui.Button) -> None:  # skipcq: PYL-W0613
+    async def bid(self, interaction: Interaction["CBot"], button: ui.Button) -> None:  # skipcq: PYL-W0613
         """Increase or make the initial bid for a user.
         Parameters
         ----------
@@ -335,7 +335,7 @@ class GiveawayView(ui.View):
     @ui.button(
         label="Check", style=discord.ButtonStyle.blurple, disabled=True
     )  # pyright: ignore[reportGeneralTypeIssues]
-    async def check(self, interaction: "Interaction[CBot]", button: ui.Button) -> None:  # skipcq: PYL-W0613
+    async def check(self, interaction: Interaction["CBot"], button: ui.Button) -> None:  # skipcq: PYL-W0613
         """Check the current bid for a user.
         Parameters
         ----------
@@ -364,7 +364,7 @@ class GiveawayView(ui.View):
         label="Toggle Giveaway Alerts", style=discord.ButtonStyle.danger
     )  # pyright: ignore[reportGeneralTypeIssues]
     async def toggle_alerts(
-        self, interaction: "Interaction[CBot]", _: ui.Button
+        self, interaction: Interaction["CBot"], _: ui.Button
     ) -> None:  # skipcq: PYL-W0613  # pragma: no cover
         """Toggle the giveaway alerts.
         Parameters
@@ -376,15 +376,15 @@ class GiveawayView(ui.View):
         """
         await interaction.response.defer(ephemeral=True, thinking=True)
         async with self.role_semaphore:
-            if all(role.id != 972886729231044638 for role in interaction.user.roles):
-                await interaction.user.add_roles(
+            if all(role.id != 972886729231044638 for role in cast(discord.Member, interaction.user).roles):
+                await cast(discord.Member, interaction.user).add_roles(
                     discord.Object(id=972886729231044638), reason="Toggled giveaway alerts."
                 )
                 await interaction.followup.send(
                     charbot_rust.translate(interaction.locale.value, "giveaway-alerts-enable", {})
                 )
             else:
-                await interaction.user.remove_roles(
+                await cast(discord.Member, interaction.user).remove_roles(
                     discord.Object(id=972886729231044638), reason="Toggled giveaway alerts."
                 )
                 await interaction.followup.send(

--- a/charbot/giveaway/view.py
+++ b/charbot/giveaway/view.py
@@ -302,7 +302,7 @@ class GiveawayView(ui.View):
         )
 
     # noinspection PyUnusedLocal
-    @ui.button(label="Bid", style=discord.ButtonStyle.green)  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Bid", style=discord.ButtonStyle.green)
     async def bid(self, interaction: Interaction["CBot"], button: ui.Button) -> None:  # skipcq: PYL-W0613
         """Increase or make the initial bid for a user.
         Parameters
@@ -332,9 +332,7 @@ class GiveawayView(ui.View):
         asyncio.create_task(_task())
 
     # noinspection PyUnusedLocal
-    @ui.button(
-        label="Check", style=discord.ButtonStyle.blurple, disabled=True
-    )  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Check", style=discord.ButtonStyle.blurple, disabled=True)
     async def check(self, interaction: Interaction["CBot"], button: ui.Button) -> None:  # skipcq: PYL-W0613
         """Check the current bid for a user.
         Parameters
@@ -360,9 +358,7 @@ class GiveawayView(ui.View):
         )
 
     # noinspection PyUnusedLocal
-    @ui.button(
-        label="Toggle Giveaway Alerts", style=discord.ButtonStyle.danger
-    )  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Toggle Giveaway Alerts", style=discord.ButtonStyle.danger)
     async def toggle_alerts(
         self, interaction: Interaction["CBot"], _: ui.Button
     ) -> None:  # skipcq: PYL-W0613  # pragma: no cover

--- a/charbot/levels.py
+++ b/charbot/levels.py
@@ -181,7 +181,7 @@ class Leveling(commands.Cog):
             elif level >= 30:
                 await member.add_roles(discord.Object(969629622453039104), reason=f"Rejoined at level {level}")
 
-    @app_commands.command()  # pyright: ignore
+    @app_commands.command()
     @app_commands.guild_only()
     @app_commands.checks.cooldown(1, 900, key=lambda interaction: interaction.user.id)
     async def rank(self, interaction: Interaction[CBot], user: Optional[discord.Member] = None):

--- a/charbot/levels.py
+++ b/charbot/levels.py
@@ -181,10 +181,10 @@ class Leveling(commands.Cog):
             elif level >= 30:
                 await member.add_roles(discord.Object(969629622453039104), reason=f"Rejoined at level {level}")
 
-    @app_commands.command()
+    @app_commands.command()  # pyright: ignore
     @app_commands.guild_only()
     @app_commands.checks.cooldown(1, 900, key=lambda interaction: interaction.user.id)
-    async def rank(self, interaction: Interaction, user: Optional[discord.Member] = None):
+    async def rank(self, interaction: Interaction[CBot], user: Optional[discord.Member] = None):
         """Check your or someone's level and rank.
 
         Parameters

--- a/charbot/mod_support.py
+++ b/charbot/mod_support.py
@@ -106,7 +106,7 @@ class ModSupport(GroupCog, name="modsupport", description="mod support command g
             if temp:
                 await channel.delete()
 
-    @app_commands.command(name="query", description="queries list of users banned from mod support")  # pyright: ignore
+    @app_commands.command(name="query", description="queries list of users banned from mod support")
     @app_commands.guild_only()
     async def query(self, interaction: Interaction[CBot]):
         """Modmail blacklist query command.
@@ -131,7 +131,7 @@ class ModSupport(GroupCog, name="modsupport", description="mod support command g
     @app_commands.command(
         name="edit",
         description="adds or removes a user from the list of users banned from mod" " support",
-    )  # pyright: ignore
+    )
     @app_commands.guild_only()
     async def edit(self, interaction: Interaction[CBot], add: bool, user: discord.Member):
         """Modmail edit blacklist command.

--- a/charbot/mod_support.py
+++ b/charbot/mod_support.py
@@ -265,13 +265,7 @@ class ModSupportButtons(ui.View):
             )
         )
 
-    @ui.button(
-        label="General",
-        style=discord.ButtonStyle.success,
-        custom_id="Modmail_General",
-        emoji="❔",
-        row=0,
-    )  # pyright: ignore
+    @ui.button(label="General", style=discord.ButtonStyle.success, custom_id="Modmail_General", emoji="❔", row=0)
     async def general(self, interaction: Interaction[CBot], button: discord.ui.Button):
         """General mod support callback.
 
@@ -284,13 +278,7 @@ class ModSupportButtons(ui.View):
         """
         await self.standard_callback(button, interaction)
 
-    @ui.button(
-        label="Important",
-        style=discord.ButtonStyle.primary,
-        custom_id="Modmail_Important",
-        emoji="❗",
-        row=0,
-    )  # pyright: ignore
+    @ui.button(label="Important", style=discord.ButtonStyle.primary, custom_id="Modmail_Important", emoji="❗", row=0)
     async def important(self, interaction: Interaction[CBot], button: discord.ui.Button):
         """Mod support callback for important issues.
 
@@ -303,13 +291,7 @@ class ModSupportButtons(ui.View):
         """
         await self.standard_callback(button, interaction)
 
-    @ui.button(
-        label="Emergency",
-        style=discord.ButtonStyle.danger,
-        custom_id="Modmail_Emergency",
-        emoji="‼",
-        row=0,
-    )  # pyright: ignore
+    @ui.button(label="Emergency", style=discord.ButtonStyle.danger, custom_id="Modmail_Emergency", emoji="‼", row=0)
     async def emergency(self, interaction: Interaction[CBot], button: discord.ui.Button):
         """Emergency mod support callback.
 
@@ -322,13 +304,7 @@ class ModSupportButtons(ui.View):
         """
         await self.standard_callback(button, interaction)
 
-    @ui.select(
-        placeholder="Private",
-        custom_id="Modmail_Private",
-        max_values=5,
-        options=_PRIVATE_OPTIONS,
-        row=1,
-    )  # pyright: ignore
+    @ui.select(placeholder="Private", custom_id="Modmail_Private", max_values=5, options=_PRIVATE_OPTIONS, row=1)
     async def private(self, interaction: Interaction[CBot], select: discord.ui.Select):
         """Private mod support callback.
 

--- a/charbot/mod_support.py
+++ b/charbot/mod_support.py
@@ -18,7 +18,7 @@ from discord.utils import utcnow
 from . import CBot
 
 
-async def edit_check(interaction: Interaction) -> bool:
+async def edit_check(interaction: Interaction[CBot]) -> bool:
     """Check for if a user is allowed to edit the blacklist.
 
     Parameters
@@ -106,9 +106,9 @@ class ModSupport(GroupCog, name="modsupport", description="mod support command g
             if temp:
                 await channel.delete()
 
-    @app_commands.command(name="query", description="queries list of users banned from mod support")
+    @app_commands.command(name="query", description="queries list of users banned from mod support")  # pyright: ignore
     @app_commands.guild_only()
-    async def query(self, interaction: Interaction):
+    async def query(self, interaction: Interaction[CBot]):
         """Modmail blacklist query command.
 
         This command is used to query the mod support blacklist.
@@ -131,9 +131,9 @@ class ModSupport(GroupCog, name="modsupport", description="mod support command g
     @app_commands.command(
         name="edit",
         description="adds or removes a user from the list of users banned from mod" " support",
-    )
+    )  # pyright: ignore
     @app_commands.guild_only()
-    async def edit(self, interaction: Interaction, add: bool, user: discord.Member):
+    async def edit(self, interaction: Interaction[CBot], add: bool, user: discord.Member):
         """Modmail edit blacklist command.
 
         Parameters
@@ -218,7 +218,7 @@ class ModSupportButtons(ui.View):
         self.mods = mods
         self.filename: Final[pathlib.Path] = pathlib.Path(__file__).parent / "mod_support_blacklist.json"
 
-    async def interaction_check(self, interaction: Interaction) -> bool:
+    async def interaction_check(self, interaction: Interaction[CBot]) -> bool:
         """Check to run for all interaction instances.
 
         Parameters
@@ -234,13 +234,13 @@ class ModSupportButtons(ui.View):
         with open(self.filename, "rb") as file:
             return interaction.user.id not in orjson.loads(file.read())["blacklisted"]
 
-    async def on_error(self, interaction: Interaction, error: Exception, item: Item[Any], /) -> None:
+    async def on_error(self, interaction: Interaction[CBot], error: Exception, item: Item[Any], /) -> None:
         """On error logger"""
         logging.getLogger("charbot.mod_support").error(
             "Ignoring exception in view %r for item %r, with user %s", self, item, interaction.user, exc_info=error
         )
 
-    async def standard_callback(self, button: discord.ui.Button, interaction: Interaction):
+    async def standard_callback(self, button: discord.ui.Button, interaction: Interaction[CBot]):
         """Just general and important and emergency callback helper.
 
         This is the callback for all buttons.
@@ -271,8 +271,8 @@ class ModSupportButtons(ui.View):
         custom_id="Modmail_General",
         emoji="❔",
         row=0,
-    )
-    async def general(self, interaction: Interaction, button: discord.ui.Button):
+    )  # pyright: ignore
+    async def general(self, interaction: Interaction[CBot], button: discord.ui.Button):
         """General mod support callback.
 
         Parameters
@@ -290,8 +290,8 @@ class ModSupportButtons(ui.View):
         custom_id="Modmail_Important",
         emoji="❗",
         row=0,
-    )
-    async def important(self, interaction: Interaction, button: discord.ui.Button):
+    )  # pyright: ignore
+    async def important(self, interaction: Interaction[CBot], button: discord.ui.Button):
         """Mod support callback for important issues.
 
         Parameters
@@ -309,8 +309,8 @@ class ModSupportButtons(ui.View):
         custom_id="Modmail_Emergency",
         emoji="‼",
         row=0,
-    )
-    async def emergency(self, interaction: Interaction, button: discord.ui.Button):
+    )  # pyright: ignore
+    async def emergency(self, interaction: Interaction[CBot], button: discord.ui.Button):
         """Emergency mod support callback.
 
         Parameters
@@ -328,8 +328,8 @@ class ModSupportButtons(ui.View):
         max_values=5,
         options=_PRIVATE_OPTIONS,
         row=1,
-    )
-    async def private(self, interaction: Interaction, select: discord.ui.Select):
+    )  # pyright: ignore
+    async def private(self, interaction: Interaction[CBot], select: discord.ui.Select):
         """Private mod support callback.
 
         This is the only callback does not use the standard_callback helper
@@ -387,7 +387,7 @@ class ModSupportModal(ui.Modal, title="Mod Support Form"):
         self.channel_name = channel_name
         self.filename = "charbot/mod_support_blacklist.json"
 
-    async def interaction_check(self, interaction: Interaction) -> bool:
+    async def interaction_check(self, interaction: Interaction[CBot]) -> bool:
         """Check to run for all interaction instances.
 
         This is used to check if the interaction user is allowed to use this modal.
@@ -422,7 +422,7 @@ class ModSupportModal(ui.Modal, title="Mod Support Form"):
         custom_id="Long_Description",
     )
 
-    async def on_submit(self, interaction: Interaction):
+    async def on_submit(self, interaction: Interaction[CBot]):
         """Submit callback.
 
         This is where the mod support form is actually submitted.
@@ -452,7 +452,7 @@ class ModSupportModal(ui.Modal, title="Mod Support Form"):
             await channel.send(self.full_description.value)
         await interaction.response.send_message(f"Channel Created: {channel.mention}", ephemeral=True)
 
-    async def on_error(self, interaction: Interaction, error: Exception) -> None:
+    async def on_error(self, interaction: Interaction[CBot], error: Exception) -> None:
         """Error handler for modal.
 
         Parameters
@@ -463,7 +463,7 @@ class ModSupportModal(ui.Modal, title="Mod Support Form"):
             The error that was raised.
         """
         await interaction.response.send_message(
-            "Oh no! Something went wrong. Please ask for a mod's help in this " "channel and let Bluesy know.",
+            "Oh no! Something went wrong. Please ask for a mod's help in this channel and let Bluesy know.",
             ephemeral=True,
         )
         self.logger.error("Ignoring exception in modal %r.", self, exc_info=error)

--- a/charbot/pools.py
+++ b/charbot/pools.py
@@ -44,33 +44,31 @@ class Pools(commands.GroupCog, name="pools", description="Reputation pools for c
     def __init__(self, bot: CBot):
         self.bot = bot
 
-        @self.add.autocomplete("pool")
-        @self.query.autocomplete("pool")
-        async def pool_autocomplete(interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
-            """Autocomplete a pool name.
+    async def pool_autocomplete(self, interaction: Interaction[CBot], current: str) -> list[app_commands.Choice[str]]:
+        """Autocomplete a pool name.
 
-            Parameters
-            ----------
-            interaction : Interaction
-                The interaction object.
-            current : str
-                The current string.
+        Parameters
+        ----------
+        interaction : Interaction
+            The interaction object.
+        current : str
+            The current string.
 
-            Returns
-            -------
-            list[app_commands.Choice[str]]
-                The list of choices.
-            """
-            member = interaction.user
-            assert isinstance(member, discord.Member)  # skipcq: BAN-B101
-            return [
-                app_commands.Choice(name=pool["pool"], value=pool["pool"])
-                for pool in await self.bot.pool.fetch("SELECT pool, required_roles FROM pools")
-                if current.lower() in pool["pool"].lower()
-                and any(role.id in pool["required_roles"] for role in member.roles)
-            ]
+        Returns
+        -------
+        list[app_commands.Choice[str]]
+            The list of choices.
+        """
+        member = interaction.user
+        assert isinstance(member, discord.Member)  # skipcq: BAN-B101
+        return [
+            app_commands.Choice(name=pool["pool"], value=pool["pool"])
+            for pool in await self.bot.pool.fetch("SELECT pool, required_roles FROM pools")
+            if current.lower() in pool["pool"].lower()
+            and any(role.id in pool["required_roles"] for role in member.roles)
+        ]
 
-    async def interaction_check(self, interaction: Interaction) -> bool:
+    async def interaction_check(self, interaction: Interaction[CBot]) -> bool:
         """Check if the interaction is valid.
 
         Parameters
@@ -103,9 +101,10 @@ class Pools(commands.GroupCog, name="pools", description="Reputation pools for c
             raise errors.WrongChannelError(969972085445238784, interaction.locale)
         return True
 
-    @app_commands.command(name="add", description="Add reputation to an active pool.")
+    @app_commands.command(name="add", description="Add reputation to an active pool.")  # pyright: ignore
+    @app_commands.autocomplete(pool=pool_autocomplete)  # pyright: ignore
     @app_commands.describe(pool="The pool to add to.", amount="The amount to add.")
-    async def add(self, interaction: Interaction, pool: str, amount: app_commands.Range[int, 1]):
+    async def add(self, interaction: Interaction[CBot], pool: str, amount: app_commands.Range[int, 1]):
         """Add reputation to an active pool.
 
         If the pool overflowed by the addition, it only fills it to the maximum.
@@ -172,9 +171,10 @@ class Pools(commands.GroupCog, name="pools", description="Reputation pools for c
             assert isinstance(channel, discord.abc.Messageable)  # skipcq: BAN-B101
             await channel.send(f"{interaction.user.mention} has filled {pool}!", file=image)
 
-    @app_commands.command(name="query", description="Check the status of an active pool.")
+    @app_commands.command(name="query", description="Check the status of an active pool.")  # pyright: ignore
+    @app_commands.autocomplete(pool=pool_autocomplete)  # pyright: ignore
     @app_commands.describe(pool="The pool to check.")
-    async def query(self, interaction: Interaction, pool: str):
+    async def query(self, interaction: Interaction[CBot], pool: str):
         """Check the status of an active pool.
 
         Parameters

--- a/charbot/pools.py
+++ b/charbot/pools.py
@@ -101,8 +101,8 @@ class Pools(commands.GroupCog, name="pools", description="Reputation pools for c
             raise errors.WrongChannelError(969972085445238784, interaction.locale)
         return True
 
-    @app_commands.command(name="add", description="Add reputation to an active pool.")  # pyright: ignore
-    @app_commands.autocomplete(pool=pool_autocomplete)  # pyright: ignore
+    @app_commands.command(name="add", description="Add reputation to an active pool.")
+    @app_commands.autocomplete(pool=pool_autocomplete)
     @app_commands.describe(pool="The pool to add to.", amount="The amount to add.")
     async def add(self, interaction: Interaction[CBot], pool: str, amount: app_commands.Range[int, 1]):
         """Add reputation to an active pool.
@@ -171,8 +171,8 @@ class Pools(commands.GroupCog, name="pools", description="Reputation pools for c
             assert isinstance(channel, discord.abc.Messageable)  # skipcq: BAN-B101
             await channel.send(f"{interaction.user.mention} has filled {pool}!", file=image)
 
-    @app_commands.command(name="query", description="Check the status of an active pool.")  # pyright: ignore
-    @app_commands.autocomplete(pool=pool_autocomplete)  # pyright: ignore
+    @app_commands.command(name="query", description="Check the status of an active pool.")
+    @app_commands.autocomplete(pool=pool_autocomplete)
     @app_commands.describe(pool="The pool to check.")
     async def query(self, interaction: Interaction[CBot], pool: str):
         """Check the status of an active pool.

--- a/charbot/programs/cog.py
+++ b/charbot/programs/cog.py
@@ -11,10 +11,10 @@ from itertools import count
 from typing import Final, Literal, cast
 
 import discord
-from discord import app_commands
+from discord import Interaction, app_commands
 from discord.ext import commands
 
-from .. import CBot, GuildInteraction as Interaction, errors
+from .. import CBot, errors
 from . import sudoku, tictactoe, shrugman
 from .minesweeper import Minesweeper
 from charbot_rust.minesweeper import Game as MinesweeperGame  # pyright: ignore[reportGeneralTypeIssues]
@@ -30,7 +30,7 @@ class Reputation(commands.Cog, name="Programs"):
         re.RegexFlag.MULTILINE | re.RegexFlag.DOTALL | re.RegexFlag.IGNORECASE,
     )
 
-    async def interaction_check(self, interaction: Interaction["CBot"]):  # skipcq: PYL-W0221
+    async def interaction_check(self, interaction: Interaction[CBot]):  # skipcq: PYL-W0221
         """Check if the user is allowed to use the cog."""
         if interaction.guild is None:
             raise app_commands.NoPrivateMessage("Programs can't be used in direct messages.")
@@ -54,7 +54,7 @@ class Reputation(commands.Cog, name="Programs"):
     beta = app_commands.Group(name="beta", description="Beta programs..", parent=programs)
 
     @programs.command(name="sudoku", description="Play a Sudoku puzzle")  # pyright: ignore[reportGeneralTypeIssues]
-    async def sudoku(self, interaction: Interaction["CBot"], mobile: bool):
+    async def sudoku(self, interaction: Interaction[CBot], mobile: bool):
         """Generate a sudoku puzzle.
 
         Parameters
@@ -80,7 +80,7 @@ class Reputation(commands.Cog, name="Programs"):
     @programs.command(
         name="tictactoe", description="Play a game of Tic Tac Toe!"
     )  # pyright: ignore[reportGeneralTypeIssues]
-    async def tictactoe(self, interaction: Interaction["CBot"], difficulty: tictactoe.Difficulty):
+    async def tictactoe(self, interaction: Interaction[CBot], difficulty: tictactoe.Difficulty):
         """Play a game of Tic Tac Toe! Now built with rust.
 
         Parameters
@@ -100,7 +100,7 @@ class Reputation(commands.Cog, name="Programs"):
     @programs.command(
         name="shrugman", description="Play the shrugman minigame. (Hangman clone)"
     )  # pyright: ignore[reportGeneralTypeIssues]
-    async def shrugman(self, interaction: Interaction["CBot"]) -> None:
+    async def shrugman(self, interaction: Interaction[CBot]) -> None:
         """Play a game of Shrugman.
 
         This game is a hangman-like game.
@@ -133,7 +133,7 @@ class Reputation(commands.Cog, name="Programs"):
     @programs.command()  # pyright: ignore[reportGeneralTypeIssues]
     async def minesweeper(
         self,
-        interaction: Interaction["CBot"],
+        interaction: Interaction[CBot],
         difficulty: Literal["Beginner", "Intermediate", "Expert", "Super Expert"],
     ):
         """Play a game of Minesweeper.
@@ -165,7 +165,7 @@ class Reputation(commands.Cog, name="Programs"):
     # noinspection SpellCheckingInspection
     @app_commands.command()  # pyright: ignore[reportGeneralTypeIssues]
     @app_commands.guild_only()
-    async def rollcall(self, interaction: Interaction["CBot"]):
+    async def rollcall(self, interaction: Interaction[CBot]):
         """Claim your daily reputation bonus.
 
         Parameters
@@ -207,7 +207,7 @@ class Reputation(commands.Cog, name="Programs"):
         name="reputation", description="Check your reputation"
     )  # pyright: ignore[reportGeneralTypeIssues]
     @app_commands.guild_only()
-    async def query_points(self, interaction: Interaction["CBot"]):
+    async def query_points(self, interaction: Interaction[CBot]):
         """Query your reputation.
 
         Parameters

--- a/charbot/programs/cog.py
+++ b/charbot/programs/cog.py
@@ -53,7 +53,7 @@ class Reputation(commands.Cog, name="Programs"):
     programs = app_commands.Group(name="programs", description="Programs to gain you rep.", guild_only=True)
     beta = app_commands.Group(name="beta", description="Beta programs..", parent=programs)
 
-    @programs.command(name="sudoku", description="Play a Sudoku puzzle")  # pyright: ignore[reportGeneralTypeIssues]
+    @programs.command(name="sudoku", description="Play a Sudoku puzzle")
     async def sudoku(self, interaction: Interaction[CBot], mobile: bool):
         """Generate a sudoku puzzle.
 
@@ -77,9 +77,7 @@ class Reputation(commands.Cog, name="Programs"):
         view = sudoku.Sudoku(sudoku.Puzzle(board, mobile), cast(discord.Member, interaction.user), interaction.client)
         await interaction.followup.send(embed=view.block_choose_embed(), view=view)
 
-    @programs.command(
-        name="tictactoe", description="Play a game of Tic Tac Toe!"
-    )  # pyright: ignore[reportGeneralTypeIssues]
+    @programs.command(name="tictactoe", description="Play a game of Tic Tac Toe!")
     async def tictactoe(self, interaction: Interaction[CBot], difficulty: tictactoe.Difficulty):
         """Play a game of Tic Tac Toe! Now built with rust.
 
@@ -97,9 +95,7 @@ class Reputation(commands.Cog, name="Programs"):
         image = await asyncio.to_thread(view.display)
         await interaction.followup.send(embed=embed, view=view, file=image)
 
-    @programs.command(
-        name="shrugman", description="Play the shrugman minigame. (Hangman clone)"
-    )  # pyright: ignore[reportGeneralTypeIssues]
+    @programs.command(name="shrugman", description="Play the shrugman minigame. (Hangman clone)")
     async def shrugman(self, interaction: Interaction[CBot]) -> None:
         """Play a game of Shrugman.
 
@@ -130,7 +126,7 @@ class Reputation(commands.Cog, name="Programs"):
         view = shrugman.Shrugman(interaction.client, word)
         await interaction.followup.send(embed=embed, view=view)
 
-    @programs.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @programs.command()
     async def minesweeper(
         self,
         interaction: Interaction[CBot],
@@ -163,7 +159,7 @@ class Reputation(commands.Cog, name="Programs"):
         await interaction.followup.send(embed=embed, view=view, file=file)
 
     # noinspection SpellCheckingInspection
-    @app_commands.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @app_commands.command()
     @app_commands.guild_only()
     async def rollcall(self, interaction: Interaction[CBot]):
         """Claim your daily reputation bonus.
@@ -203,9 +199,7 @@ class Reputation(commands.Cog, name="Programs"):
             )
         await interaction.followup.send("You got some Rep today, inmate")
 
-    @app_commands.command(
-        name="reputation", description="Check your reputation"
-    )  # pyright: ignore[reportGeneralTypeIssues]
+    @app_commands.command(name="reputation", description="Check your reputation")
     @app_commands.guild_only()
     async def query_points(self, interaction: Interaction[CBot]):
         """Query your reputation.

--- a/charbot/programs/minesweeper.py
+++ b/charbot/programs/minesweeper.py
@@ -135,7 +135,7 @@ class Minesweeper(ui.View):
         await interaction.edit_original_response(attachments=[file], embed=embed, view=None)
         self.stop()
 
-    @ui.select(placeholder="Select a row")  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.select(placeholder="Select a row")
     async def row(self, interaction: Interaction[CBot], select: ui.Select[Self]):
         """Change the row.
 
@@ -155,7 +155,7 @@ class Minesweeper(ui.View):
             opt.default = opt.value == val
         await interaction.response.edit_message(attachments=[file], view=self)
 
-    @ui.select(placeholder="Select a column")  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.select(placeholder="Select a column")
     async def column(self, interaction: Interaction[CBot], select: ui.Select[Self]):
         """Change the column.
 
@@ -175,7 +175,7 @@ class Minesweeper(ui.View):
             opt.default = opt.value == val
         await interaction.response.edit_message(attachments=[file], view=self)
 
-    @ui.button(label="Reveal", style=ButtonStyle.primary, emoji="\u26cf")  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Reveal", style=ButtonStyle.primary, emoji="\u26cf")
     async def reveal(self, interaction: Interaction[CBot], _button: ui.Button[Self]):
         """Reveal a tile.
 
@@ -203,7 +203,7 @@ class Minesweeper(ui.View):
                 )
 
     # noinspection GrazieInspection
-    @ui.button(label="Chord", style=ButtonStyle.primary, emoji="\u2692")  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Chord", style=ButtonStyle.primary, emoji="\u2692")
     async def chord(self, interaction: Interaction[CBot], _button: ui.Button[Self]):
         """Chord a tile.
 
@@ -231,7 +231,7 @@ class Minesweeper(ui.View):
         else:
             await self.handle_lose(interaction)
 
-    @ui.button(label="Flag", style=ButtonStyle.success, emoji="\U0001f6a9")  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Flag", style=ButtonStyle.success, emoji="\U0001f6a9")
     async def flag(self, interaction: Interaction[CBot], _button: ui.Button[Self]):
         """Flag a tile.
 
@@ -253,7 +253,7 @@ class Minesweeper(ui.View):
                 translate(interaction.locale.value, "minesweeper-flag-error", {}), ephemeral=True
             )
 
-    @ui.button(label="Quit", style=ButtonStyle.danger, emoji="\u2620")  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Quit", style=ButtonStyle.danger, emoji="\u2620")
     async def quit(self, interaction: Interaction[CBot], _button: ui.Button[Self]):
         """Quit the game.
 
@@ -277,7 +277,7 @@ class Minesweeper(ui.View):
         await interaction.response.edit_message(attachments=[file], embed=embed, view=None)
         self.stop()
 
-    @ui.button(label="Help", style=ButtonStyle.secondary, emoji="\u2049")  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Help", style=ButtonStyle.secondary, emoji="\u2049")
     async def help(self, interaction: Interaction[CBot], _button: ui.Button[Self]):
         """Display the help message.
 

--- a/charbot/programs/minesweeper.py
+++ b/charbot/programs/minesweeper.py
@@ -10,10 +10,10 @@ from io import BytesIO
 
 import discord
 from PIL import Image
-from discord import ButtonStyle, ui, SelectOption
+from discord import ButtonStyle, Interaction, SelectOption, ui
 from typing_extensions import Self
 
-from .. import GuildComponentInteraction as Interaction, CBot, translate
+from .. import CBot, translate
 from charbot_rust import minesweeper
 
 

--- a/charbot/programs/tictactoe.py
+++ b/charbot/programs/tictactoe.py
@@ -14,10 +14,10 @@ from typing_extensions import Self
 
 import discord
 from PIL import Image
-from discord import ButtonStyle, ui
+from discord import ButtonStyle, Interaction, ui
 from discord.utils import utcnow
 
-from .. import GuildComponentInteraction as Interaction, CBot
+from .. import CBot
 from charbot_rust.tictactoe import Game, Difficulty, Piece  # pyright: ignore[reportGeneralTypeIssues]
 
 

--- a/charbot/programs/tictactoe.py
+++ b/charbot/programs/tictactoe.py
@@ -157,7 +157,7 @@ class TicTacToe(ui.View):
             image = await asyncio.to_thread(self.display)
             await interaction.edit_original_response(attachments=[image], view=self)
 
-    @ui.button(style=ButtonStyle.green, emoji="✅")  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(style=ButtonStyle.green, emoji="✅")
     async def top_left(self, interaction: Interaction[CBot], button: ui.Button):
         """Call when top left button is pressed.
 
@@ -170,7 +170,7 @@ class TicTacToe(ui.View):
         """
         await self.move(interaction, button, 0)
 
-    @ui.button(style=ButtonStyle.green, emoji="✅")  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(style=ButtonStyle.green, emoji="✅")
     async def top_mid(self, interaction: Interaction[CBot], button: ui.Button):
         """Call when top middle button is pressed.
 
@@ -183,7 +183,7 @@ class TicTacToe(ui.View):
         """
         await self.move(interaction, button, 1)
 
-    @ui.button(style=ButtonStyle.green, emoji="✅")  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(style=ButtonStyle.green, emoji="✅")
     async def top_right(self, interaction: Interaction[CBot], button: ui.Button):
         """Call when top right button is pressed.
 
@@ -197,7 +197,7 @@ class TicTacToe(ui.View):
         await self.move(interaction, button, 2)
 
     # noinspection PyUnusedLocal
-    @ui.button(label="Cancel", style=ButtonStyle.danger)  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(label="Cancel", style=ButtonStyle.danger)
     async def cancel(self, interaction: Interaction[CBot], button: ui.Button):  # skipcq: PYL-W0613
         """Call when cancel button is pressed.
 
@@ -217,7 +217,7 @@ class TicTacToe(ui.View):
         embed.set_footer(text="Start playing by typing /programs tictactoe")
         await interaction.response.edit_message(embed=embed)
 
-    @ui.button(style=ButtonStyle.green, emoji="✅", row=1)  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(style=ButtonStyle.green, emoji="✅", row=1)
     async def mid_left(self, interaction: Interaction[CBot], button: ui.Button):
         """Call when middle left button is pressed.
 
@@ -230,7 +230,7 @@ class TicTacToe(ui.View):
         """
         await self.move(interaction, button, 3)
 
-    @ui.button(style=ButtonStyle.green, emoji="✅", row=1)  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(style=ButtonStyle.green, emoji="✅", row=1)
     async def mid_mid(self, interaction: Interaction[CBot], button: ui.Button):
         """Call when middle_middle button is pressed.
 
@@ -243,7 +243,7 @@ class TicTacToe(ui.View):
         """
         await self.move(interaction, button, 4)
 
-    @ui.button(style=ButtonStyle.green, emoji="✅", row=1)  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(style=ButtonStyle.green, emoji="✅", row=1)
     async def mid_right(self, interaction: Interaction[CBot], button: ui.Button):
         """Call when middle right button is pressed.
 
@@ -256,7 +256,7 @@ class TicTacToe(ui.View):
         """
         await self.move(interaction, button, 5)
 
-    @ui.button(style=ButtonStyle.green, emoji="✅", row=2)  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(style=ButtonStyle.green, emoji="✅", row=2)
     async def bot_left(self, interaction: Interaction[CBot], button: ui.Button):
         """Call when bottom left button is pressed.
 
@@ -269,7 +269,7 @@ class TicTacToe(ui.View):
         """
         await self.move(interaction, button, 6)
 
-    @ui.button(style=ButtonStyle.green, emoji="✅", row=2)  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(style=ButtonStyle.green, emoji="✅", row=2)
     async def bot_mid(self, interaction: Interaction[CBot], button: ui.Button):
         """Call when bottom middle button is pressed.
 
@@ -282,7 +282,7 @@ class TicTacToe(ui.View):
         """
         await self.move(interaction, button, 7)
 
-    @ui.button(style=ButtonStyle.green, emoji="✅", row=2)  # pyright: ignore[reportGeneralTypeIssues]
+    @ui.button(style=ButtonStyle.green, emoji="✅", row=2)
     async def bot_right(self, interaction: Interaction[CBot], button: ui.Button):
         """Call when bottom right button is pressed.
 

--- a/charbot/query.py
+++ b/charbot/query.py
@@ -11,19 +11,19 @@ from zoneinfo import ZoneInfo
 
 import discord
 import pytesseract
-from discord import app_commands
+from discord import Interaction, app_commands
 from discord.ext import commands, tasks
 from discord.ext.commands import Cog, Context
 from PIL import Image, ImageOps
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from . import CBot, GuildInteraction as Interaction
+    from . import CBot
 
 
 __rules__: Final[dict[int, str]] = {
     1: "Be respectful to others. Being drunk is not an excuse for being stupid. Common-sense matters."
-    " Just because it isn’t explicitly written here, doesn't mean it doesn't break the rules.",
+    " Just because it isn't explicitly written here, doesn't mean it doesn't break the rules.",
     2: "Please utilize the text and voice channels as they are described and keep things on topic."
     " Please be open to explaining and including others for any conversation you have here.",
     3: "Don't spam. Intentionally spamming gets you kicked or muted. Whether or not you are spamming is subject to"
@@ -39,7 +39,7 @@ __rules__: Final[dict[int, str]] = {
     8: "Discord invites and promotions of your own content anywhere but <#298485559813210115> are restricted, "
     "if you wish to post one somewhere please check with Mods",
     9: "Please respect the Mods here. They are good people who sincerely want this environment to be awesome too. "
-    "If they’re advising you to change your behavior, it’s the same as me doing it. Please listen.",
+    "If they're advising you to change your behavior, it's the same as me doing it. Please listen.",
     10: "Some language will be deleted. I like the idea of maintaining a PG-13 community environment. "
     "Find a way to say it another way, if the bot kills your message.",
 }
@@ -150,7 +150,7 @@ class Query(Cog):
         Repository:
         https://github.com/Bluesy1/CharB0T/tree/main/charbot
 
-        Licence:
+        License:
         MIT - https://github.com/Bluesy1/CharB0T/blob/master/LICENSE
 
         Parameters
@@ -264,7 +264,7 @@ class Query(Cog):
     @app_commands.guild_only()
     async def rules(
         self,
-        interaction: "Interaction[CBot]",
+        interaction: Interaction["CBot"],
         rule: app_commands.Range[int, 1, 10] | None = None,
         member: discord.Member | None = None,
     ):
@@ -272,7 +272,7 @@ class Query(Cog):
 
         Parameters
         ----------
-        interaction: Interaction[CBot]
+        interaction: Interaction
             The interaction of the command.
         rule: app_commands.Range[int, 1, 10] | None
             The rule to get, if None, all rules are returned.
@@ -297,12 +297,12 @@ class Query(Cog):
 
     @app_commands.command()  # pyright: ignore[reportGeneralTypeIssues]
     @app_commands.guild_only()
-    async def leaderboard(self, interaction: "Interaction[CBot]", ephemeral: bool = True):
+    async def leaderboard(self, interaction: Interaction["CBot"], ephemeral: bool = True):
         """Get the leaderboard of the server.
 
         Parameters
         ----------
-        interaction: Interaction[CBot]
+        interaction: Interaction
             The interaction of the command.
         ephemeral: bool, default True
             Send the leaderboard as an ephemeral message. Default True.

--- a/charbot/query.py
+++ b/charbot/query.py
@@ -260,7 +260,7 @@ class Query(Cog):
         """Clear the OCR done set."""
         self.ocr_done.clear()
 
-    @app_commands.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @app_commands.command()
     @app_commands.guild_only()
     async def rules(
         self,
@@ -295,7 +295,7 @@ class Query(Cog):
         else:
             await interaction.response.send_message(resp, ephemeral=True)
 
-    @app_commands.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @app_commands.command()
     @app_commands.guild_only()
     async def leaderboard(self, interaction: Interaction["CBot"], ephemeral: bool = True):
         """Get the leaderboard of the server.

--- a/charbot/reputation_admin.py
+++ b/charbot/reputation_admin.py
@@ -8,11 +8,11 @@ from typing import Optional, cast
 
 import asyncpg
 import discord
-from discord import app_commands
+from discord import Interaction, app_commands
 from discord.ext import commands, tasks
 from discord.utils import utcnow, sleep_until
 
-from . import CBot, GuildInteraction as Interaction
+from . import CBot
 from .card import generate_card
 
 
@@ -725,7 +725,7 @@ class ReputationAdmin(
         except ValueError:
             await interaction.followup.send("Invalid color, it is being ignored.")
             _color = discord.utils.MISSING
-        role = await interaction.guild.create_role(
+        role = await cast(discord.Guild, interaction.guild).create_role(
             name=f"{user.name}'s deal",
             color=_color,
             hoist=hoist,
@@ -733,7 +733,9 @@ class ReputationAdmin(
             reason=f"{interaction.user} (id: {interaction.user.id}) requested a deal or no deal role role for"
             f" {user.name} (id: {user.id})",
         )
-        await interaction.guild.edit_role_positions({role: above.position + 1}, reason="Correct placement of deal role")
+        await cast(discord.Guild, interaction.guild).edit_role_positions(
+            {role: above.position + 1}, reason="Correct placement of deal role"
+        )
         await self.bot.pool.execute(
             "INSERT INTO deal_no_deal (user_id, role_id, until) VALUES ($1, $2, $3)",
             user.id,

--- a/charbot/reputation_admin.py
+++ b/charbot/reputation_admin.py
@@ -37,10 +37,7 @@ class ReputationAdmin(
 
     def __init__(self, bot: CBot):
         self.bot = bot
-        self.ctx_menu = app_commands.ContextMenu(
-            name="Check User's Reputation",
-            callback=self.check_reputation_context,  # pyright: ignore[reportGeneralTypeIssues]
-        )
+        self.ctx_menu = app_commands.ContextMenu(name="Check User's Reputation", callback=self.check_reputation_context)
         self.bot.tree.add_command(self.ctx_menu)
         self._allowed_roles: list[int | str] = [
             225413350874546176,
@@ -53,7 +50,7 @@ class ReputationAdmin(
         @self.edit_pool.autocomplete("pool")
         @self.pool_role.autocomplete("pool")
         @self.check_pool.autocomplete("pool")
-        @self.delete_pool.autocomplete("pool")  # pyright: ignore[reportGeneralTypeIssues]
+        @self.delete_pool.autocomplete("pool")
         async def pool_autocomplete(
             interaction: Interaction[CBot], current: str  # skipcq: PYL-W0613
         ) -> list[app_commands.Choice[str]]:
@@ -115,7 +112,7 @@ class ReputationAdmin(
             raise app_commands.MissingAnyRole(self.allowed_roles)
         return True
 
-    @pools.command(name="create")  # pyright: ignore[reportGeneralTypeIssues]
+    @pools.command(name="create")
     async def create_pool(
         self,
         interaction: Interaction[CBot],
@@ -248,7 +245,7 @@ class ReputationAdmin(
             avatar_url=client_user.display_avatar.url,
         )
 
-    @pools.command(name="edit")  # pyright: ignore[reportGeneralTypeIssues]
+    @pools.command(name="edit")
     async def edit_pool(
         self,
         interaction: Interaction[CBot],
@@ -370,7 +367,7 @@ class ReputationAdmin(
             f"Pool {name or pool}{f' (formerly {pool})' if name is not None else ''} edited!", file=image
         )
 
-    @pools.command(name="list")  # pyright: ignore[reportGeneralTypeIssues]
+    @pools.command(name="list")
     async def list_pools(self, interaction: Interaction[CBot]):
         """List all pools.
 
@@ -384,7 +381,7 @@ class ReputationAdmin(
             pools = [pool["pool"] for pool in await conn.fetch("SELECT pool FROM pools")]
             await interaction.followup.send(f"Pools: {', '.join(pools)}")
 
-    @pools.command(name="role")  # pyright: ignore[reportGeneralTypeIssues]
+    @pools.command(name="role")
     async def pool_role(self, interaction: Interaction[CBot], pool: str, role: discord.Role):
         """Toggle a role's ability to participate in a pool.
 
@@ -430,7 +427,7 @@ class ReputationAdmin(
                     avatar_url=client_user.display_avatar.url,
                 )
 
-    @pools.command(name="delete")  # pyright: ignore[reportGeneralTypeIssues]
+    @pools.command(name="delete")
     async def delete_pool(self, interaction: Interaction[CBot], pool: str):
         """Delete a pool.
 
@@ -457,7 +454,7 @@ class ReputationAdmin(
                     avatar_url=client_user.display_avatar.url,
                 )
 
-    @pools.command(name="check")  # pyright: ignore[reportGeneralTypeIssues]
+    @pools.command(name="check")
     async def check_pool(self, interaction: Interaction[CBot], pool: str):
         """Check a pool.
 
@@ -492,7 +489,7 @@ class ReputationAdmin(
                     allowed_mentions=_ALLOWED_MENTIONS,
                 )
 
-    @reputation.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @reputation.command()
     async def add_reputation(self, interaction: Interaction[CBot], user: discord.User, amount: int):
         """Add reputation to a user.
 
@@ -523,7 +520,7 @@ class ReputationAdmin(
                     avatar_url=client_user.display_avatar.url,
                 )
 
-    @reputation.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @reputation.command()
     async def remove_reputation(self, interaction: Interaction[CBot], user: discord.User, amount: int):
         """Remove reputation from a user.
 
@@ -562,7 +559,7 @@ class ReputationAdmin(
                 )
 
     # noinspection DuplicatedCode
-    @reputation.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @reputation.command()
     async def check_reputation(self, interaction: Interaction[CBot], user: discord.User):
         """Check a user's reputation.
 
@@ -602,7 +599,7 @@ class ReputationAdmin(
             else:
                 await interaction.followup.send(f"User `{user.name}` has {_user['points']} reputation.")
 
-    @levels.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @levels.command()
     async def noxp_role(self, interaction: Interaction[CBot], role: discord.Role):
         """Toggles a roles ability to block xp gain.
 
@@ -633,7 +630,7 @@ class ReputationAdmin(
                 )
                 await interaction.followup.send(f"Role `{role.name}` added to noxp.")
 
-    @levels.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @levels.command()
     async def no_xp_channel(self, interaction: Interaction[CBot], channel: discord.TextChannel | discord.VoiceChannel):
         """Toggles a channels ability to block xp gain.
 
@@ -664,7 +661,7 @@ class ReputationAdmin(
                 )
                 await interaction.followup.send(f"{channel.mention} added to noxp.")
 
-    @levels.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @levels.command()
     async def noxp_query(self, interaction: Interaction[CBot]):
         """Sees the channels and roles that are banned from gaining xp.
 
@@ -692,7 +689,7 @@ class ReputationAdmin(
                 embed.add_field(name="Roles", value=", ".join(f"<@&{r}>" for r in noxp["roles"]), inline=False)
                 await interaction.followup.send(embed=embed)
 
-    @app_commands.command()  # pyright: ignore[reportGeneralTypeIssues]
+    @app_commands.command()
     async def deal_role(
         self,
         interaction: Interaction[CBot],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 dependencies = [
 	"aiohttp[speedups]==3.8.3",
 	"asyncpg==0.27.0",
-	"discord.py[speed] @ git+https://github.com/Rapptz/discord.py@2e737e70defc3ea33fe113b9d26f43cb28df03c5#egg=discord.py",
+	"discord.py[speed] @ git+https://github.com/Rapptz/discord.py@bbba8c650fcb54e9cd69b6a0f6b162fcf277f9f5#egg=discord.py",
 	"disrank==0.0.2",
 	"jishaku @ git+https://github.com/Gorialis/jishaku@d5ee79d01b2f95d52713cd189e72964050089d63#egg=jishaku",
 	"orjson==3.8.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,18 +32,18 @@ classifiers = [
 dependencies = [
 	"aiohttp[speedups]==3.8.3",
 	"asyncpg==0.27.0",
-	"discord.py[speed] @ git+https://github.com/Rapptz/discord.py@cd6fd13a8f144fade2e18d9aa2d40295635a10b6#egg=discord.py",
+	"discord.py[speed] @ git+https://github.com/Rapptz/discord.py@980fe7b0f9cc6cc1d4e705261debaeef3e420456#egg=discord.py",
 	"disrank==0.0.2",
-	"jishaku @ git+https://github.com/Gorialis/jishaku@a2a3752e4f540b10a96b5c285771b1534e3040fa#egg=jishaku",
+	"jishaku @ git+https://github.com/Gorialis/jishaku@d5ee79d01b2f95d52713cd189e72964050089d63#egg=jishaku",
 	"orjson==3.8.5",
 	"pandas==1.5.2",
 	"Pillow==9.4.0",
 	"pytesseract==0.3.10",
 	"sentry-sdk==1.13.0",
-	"tomli == 2.0.1; python_version < '3.11'",
-	"typing-extensions == 4.4.0",
+	"tomli==2.0.1; python_version < '3.11'",
+	"typing-extensions==4.4.0",
 	"urlextract==1.8.0",
-	"uvloop == 0.17.0 ; sys_platform != 'win32'",
+	"uvloop==0.17.0 ; sys_platform != 'win32'",
 	"validators==0.20.0",
 ]
 
@@ -51,16 +51,16 @@ dependencies = [
 dev = [
 	"aioresponses==0.7.4",
 	"asyncpg-stubs==0.27.0",
-	"black == 22.12.0",
+	"black==22.12.0",
 	"flake8==6.0.0",
 	"maturin[zig]==0.14.10",
-	"pre-commit == 2.21.0",
+	"pre-commit==2.21.0",
 	"pyright>=1.1.265",
-	"pytest == 7.2.1",
-	"pytest-asyncio == 0.20.3",
-	"pytest-cov == 4.0.0",
+	"pytest==7.2.1",
+	"pytest-asyncio==0.20.3",
+	"pytest-cov==4.0.0",
 	"pytest-mock==3.10.0",
-	"toml == 0.10.2",
+	"toml==0.10.2",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 dependencies = [
 	"aiohttp[speedups]==3.8.3",
 	"asyncpg==0.27.0",
-	"discord.py[speed] @ git+https://github.com/Rapptz/discord.py@980fe7b0f9cc6cc1d4e705261debaeef3e420456#egg=discord.py",
+	"discord.py[speed] @ git+https://github.com/Rapptz/discord.py@2e737e70defc3ea33fe113b9d26f43cb28df03c5#egg=discord.py",
 	"disrank==0.0.2",
 	"jishaku @ git+https://github.com/Gorialis/jishaku@d5ee79d01b2f95d52713cd189e72964050089d63#egg=jishaku",
 	"orjson==3.8.5",

--- a/tests/charbot/test_minesweeper.py
+++ b/tests/charbot/test_minesweeper.py
@@ -5,9 +5,10 @@ from typing import Any
 
 import discord
 import pytest
+from discord import Interaction
 from pytest_mock import MockerFixture
 
-from charbot import CBot, GuildComponentInteraction as Interaction
+from charbot import CBot
 from charbot.programs import minesweeper
 from charbot_rust.minesweeper import Game, RevealResult, ChordResult  # pyright: ignore[reportGeneralTypeIssues]
 

--- a/tests/charbot/test_query.py
+++ b/tests/charbot/test_query.py
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: MIT
 import discord
 import pytest
+from discord import Interaction
 from discord.ext import commands
 from pytest_mock import MockerFixture
 
-from charbot import query, GuildInteraction, CBot
+from charbot import query, CBot
 
 
 def test_cog_check_no_guild(mocker: MockerFixture):
@@ -88,7 +89,7 @@ async def test_source_command(mocker: MockerFixture):
 @pytest.mark.parametrize("rule,member_id,expected_key", [(None, None, 1), (None, 1, 2), (1, None, 3), (1, 1, 4)])
 async def test_rule_command(mocker: MockerFixture, rule: int | None, member_id: int | None, expected_key: int):
     """Test rule command."""
-    mock_itx = mocker.AsyncMock(spec=GuildInteraction[CBot])
+    mock_itx = mocker.AsyncMock(spec=Interaction[CBot])
     mock_itx.user = mocker.AsyncMock(spec=discord.Member)
     mock_itx.user.id = member_id
     mock_itx.user.mention = f"<@{member_id}>"
@@ -155,9 +156,7 @@ async def test_rule_command(mocker: MockerFixture, rule: int | None, member_id: 
 @pytest.mark.parametrize("ephemeral", [True, False])
 async def test_leaderboard_command(mocker: MockerFixture, ephemeral: bool):
     """Test leaderboard command."""
-    mock_itx = mocker.AsyncMock(
-        spec=GuildInteraction[CBot], response=mocker.AsyncMock(spec=discord.InteractionResponse)
-    )
+    mock_itx = mocker.AsyncMock(spec=Interaction[CBot], response=mocker.AsyncMock(spec=discord.InteractionResponse))
     cog = query.Query(mocker.AsyncMock(spec=CBot))
     await cog.leaderboard.callback(cog, mock_itx, ephemeral)  # pyright: ignore[reportGeneralTypeIssues]
     mock_itx.response.send_message.assert_awaited_once_with("https://cpry.net/leaderboard", ephemeral=ephemeral)

--- a/tests/charbot/test_query.py
+++ b/tests/charbot/test_query.py
@@ -105,7 +105,7 @@ async def test_rule_command(mocker: MockerFixture, rule: int | None, member_id: 
         res
         == {
             1: "**1**: Be respectful to others. Being drunk is not an excuse for being stupid. Common-sense matters"
-            ". Just because it isn’t explicitly written here, doesn't mean it doesn't break the rules.\n**2**: Please"
+            ". Just because it isn't explicitly written here, doesn't mean it doesn't break the rules.\n**2**: Please"
             " utilize the text and voice channels as they are described and keep things on topic. Please be open to"
             " explaining and including others for any conversation you have here.\n**3**: Don't spam. Intentionally"
             " spamming gets you kicked or muted. Whether or not you are spamming is subject to interpretation of"
@@ -118,12 +118,12 @@ async def test_rule_command(mocker: MockerFixture, rule: int | None, member_id: 
             " and nothing X rated. Insta-ban for anyone posting pornography, etc.\n**8**: Discord invites"
             " and promotions of your own content anywhere but <#298485559813210115> are restricted, if you wish"
             " to post one somewhere please check with Mods\n**9**: Please respect the Mods here. They are good people"
-            " who sincerely want this environment to be awesome too. If they’re advising you to change your behavior,"
-            " it’s the same as me doing it. Please listen.\n**10**: Some language will be deleted. I like the idea of"
+            " who sincerely want this environment to be awesome too. If they're advising you to change your behavior,"
+            " it's the same as me doing it. Please listen.\n**10**: Some language will be deleted. I like the idea of"
             " maintaining a PG-13 community environment. Find a way to say it another way, if the bot kills your"
             " message.",
             2: "<@1>:\n**1**: Be respectful to others. Being drunk is not an excuse for being stupid. Common-sense "
-            "matters. Just because it isn’t explicitly written here, doesn't mean it doesn't break the rules.\n**2**: "
+            "matters. Just because it isn't explicitly written here, doesn't mean it doesn't break the rules.\n**2**: "
             "Please utilize the text and voice channels as they are described and keep things on topic. Please be open"
             " to explaining and including others for any conversation you have here.\n**3**: Don't spam. Intentionally"
             " spamming gets you kicked or muted. Whether or not you are spamming is subject to interpretation of"
@@ -136,16 +136,16 @@ async def test_rule_command(mocker: MockerFixture, rule: int | None, member_id: 
             " and nothing X rated. Insta-ban for anyone posting pornography, etc.\n**8**: Discord invites"
             " and promotions of your own content anywhere but <#298485559813210115> are restricted, if you wish"
             " to post one somewhere please check with Mods\n**9**: Please respect the Mods here. They are good people"
-            " who sincerely want this environment to be awesome too. If they’re advising you to change your behavior,"
-            " it’s the same as me doing it. Please listen.\n**10**: Some language will be deleted. I like the idea of"
+            " who sincerely want this environment to be awesome too. If they're advising you to change your behavior,"
+            " it's the same as me doing it. Please listen.\n**10**: Some language will be deleted. I like the idea of"
             " maintaining a PG-13 community environment. Find a way to say it another way, if the bot kills your"
             " message.",
             3: "**Rule 1** is Be respectful to others. Being drunk is not an excuse for being stupid. "
-            "Common-sense matters. Just because it isn’t explicitly written here, doesn't mean it doesn't break the "
+            "Common-sense matters. Just because it isn't explicitly written here, doesn't mean it doesn't break the "
             "rules.\n The rules can be found here: "
             "<https://cpry.net/DiscordRules>",
             4: "<@1>:\n**Rule 1** is Be respectful to others. Being drunk is not an excuse for being stupid. "
-            "Common-sense matters. Just because it isn’t explicitly written here, doesn't mean it doesn't break the "
+            "Common-sense matters. Just because it isn't explicitly written here, doesn't mean it doesn't break the "
             "rules.\n The rules can be found here: "
             "<https://cpry.net/DiscordRules>",
         }[expected_key]


### PR DESCRIPTION
<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged and all of them need to be checked
-->
## Checklist
- [x] I have read the [contributing guidelines](https://github.com/Bluesy1/CharB0T/blob/main/CONTRIBUTING.md).
- [x] The changes are for an issue, or have been discussed with Bluesy.
- [x] I have checked the code for syntax errors or non conforming style and fixed them to the best of my ability.
<!-- The latest released python version (3.11.X) is targeted -->

<!--
Write down the changes this PR introduces.
If there are breaking changes list them separately.
-->
## Changelog
- Replace custom generic versions of `discord.Interaction` with the library one now that `discord.py` updated to support generics on client in the typing of `discord.Interaction`

### Breaking Changes


<!--
A brief description of what this PR is about if the title is not sufficient
-->
## Description


<!-- Replace "NaN" with an issue number if this is a response to an issue -->
Closes: NaN
